### PR TITLE
added jQuery init for Greasemonkey

### DIFF
--- a/dist/userscript/husot.user.js
+++ b/dist/userscript/husot.user.js
@@ -16,6 +16,9 @@
 // @require      https://www.promisejs.org/polyfills/promise-6.1.0.min.js
 // ==/UserScript==
 
+// jQuery init (for Greasemonkey)
+this.$ = this.jQuery = jQuery.noConflict(true);
+
 // Constants
 
 var husot = husot || {};

--- a/src/userscript/manifest.txt
+++ b/src/userscript/manifest.txt
@@ -15,3 +15,6 @@
 // @require      https://code.jquery.com/jquery-1.11.2.min.js
 // @require      https://www.promisejs.org/polyfills/promise-6.1.0.min.js
 // ==/UserScript==
+
+// jQuery init (for Greasemonkey)
+this.$ = this.jQuery = jQuery.noConflict(true);


### PR DESCRIPTION
In Firefox with Greasemonkey line with `$('.husot-modalOverlay')` raised 
`ReferenceError: $ is not defined`.

Tested in Firefox with Greasemonkey and in Chrome with Tampermonkey.